### PR TITLE
Switch string.replaceAll by string.replace using regex to better browser compatibility

### DIFF
--- a/modules/core/src/format.test.ts
+++ b/modules/core/src/format.test.ts
@@ -1,0 +1,13 @@
+import { formatText } from './format'
+
+describe('formatText function', () => {
+  test('Should replace parameters {n} with the following param index', () => {
+    const result = formatText('Text {0} {1}', 'param1', 'param2')
+    expect(result).toEqual('Text param1 param2')
+  })
+
+  test('Should replace repeated parameters with the same value of the following index', () => {
+    const result = formatText('Text {0} {0} {1}', 'param1', 'param2')
+    expect(result).toEqual('Text param1 param1 param2')
+  })
+})

--- a/modules/core/src/format.ts
+++ b/modules/core/src/format.ts
@@ -1,6 +1,7 @@
 export function formatText(text: string, ...args: unknown[]): string {
   return args.reduce<string>(
-    (acc, arg, index) => acc.replaceAll(`{${index}}`, String(arg)),
+    (acc, arg, index) =>
+      acc.replace(new RegExp(`\\{${index}\\}`, 'g'), String(arg)),
     text,
   )
 }


### PR DESCRIPTION
* [Switch string.replaceAll by string.replace using regex to better browser compatibility](https://github.com/leandrohsilveira/i18nlite/commit/cdb37fa9dd43c61bf5a946d25d0a8ece9c657d05) 
